### PR TITLE
feat: Catch config-file error

### DIFF
--- a/lib/cli/bootstrap.js
+++ b/lib/cli/bootstrap.js
@@ -37,6 +37,10 @@ const cli = meow(`
       type: 'boolean',
       alias: 's',
     },
+    help: {
+      type: 'boolean',
+      alias: 'h',
+    },
   },
 })
 

--- a/lib/common/getQuestions.js
+++ b/lib/common/getQuestions.js
@@ -61,8 +61,25 @@ module.exports = ({ questions, options, pkg }) => {
 
   // Get from module
   const confPath = path.resolve(options.config)
-  // eslint-disable-next-line import/no-dynamic-require,global-require
-  const config = require(confPath)
+
+  let config
+
+  try {
+    // eslint-disable-next-line import/no-dynamic-require,global-require
+    config = require(confPath)
+  } catch (e) {
+    if (typeof config !== 'function') {
+      console.log(
+        chalk(e),
+        chalk.yellow(`
+| Config file error.
+  See usage: https://github.com/a-nozeret/prompt-run#questions-config-file
+  "prompt-run -h" for help`),
+      )
+      process.exit(1)
+    }
+  }
+
 
   return config()
 }


### PR DESCRIPTION
Making sure that running `prompt-run` without any args gives helpful feedback